### PR TITLE
sendgrid/csharp-http-client#1 Adding port of the http client to Aspne…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ CSharpHTTPClient/packages/
 CSharpHTTPClient/CSharpHTTPClient.sln.VisualState.xml
 *.pfx
 *.PublicKey
+project.lock.json

--- a/NetCore/CSharpHTTPClient.sln
+++ b/NetCore/CSharpHTTPClient.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{005FE017-F738-4C16-9548-89C39600F1EA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FCEEA0BD-11CB-4DB8-94D0-E705B99B071D}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "SendGrid.CSharp.HTTP.Client", "src\SendGrid.CSharp.HTTP.Client\SendGrid.CSharp.HTTP.Client.xproj", "{DE550D30-B53D-4256-AEBD-31FE5F4A43BA}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Example", "src\Example\Example.xproj", "{0D6C6178-0950-41CA-AEB4-546F3FCFE9EE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{6A21EE25-6B85-4D59-924A-4891D7576EB7}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "UnitTest", "test\UnitTest\UnitTest.xproj", "{661B8EEA-0919-4B66-ABB6-449432053CBA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DE550D30-B53D-4256-AEBD-31FE5F4A43BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE550D30-B53D-4256-AEBD-31FE5F4A43BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE550D30-B53D-4256-AEBD-31FE5F4A43BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE550D30-B53D-4256-AEBD-31FE5F4A43BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D6C6178-0950-41CA-AEB4-546F3FCFE9EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D6C6178-0950-41CA-AEB4-546F3FCFE9EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D6C6178-0950-41CA-AEB4-546F3FCFE9EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D6C6178-0950-41CA-AEB4-546F3FCFE9EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{661B8EEA-0919-4B66-ABB6-449432053CBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{661B8EEA-0919-4B66-ABB6-449432053CBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{661B8EEA-0919-4B66-ABB6-449432053CBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{661B8EEA-0919-4B66-ABB6-449432053CBA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{DE550D30-B53D-4256-AEBD-31FE5F4A43BA} = {005FE017-F738-4C16-9548-89C39600F1EA}
+		{0D6C6178-0950-41CA-AEB4-546F3FCFE9EE} = {005FE017-F738-4C16-9548-89C39600F1EA}
+		{661B8EEA-0919-4B66-ABB6-449432053CBA} = {6A21EE25-6B85-4D59-924A-4891D7576EB7}
+	EndGlobalSection
+EndGlobal

--- a/NetCore/global.json
+++ b/NetCore/global.json
@@ -1,0 +1,6 @@
+﻿{
+  "projects": [ "src", "test" ],
+  "sdk": {
+    "version": "1.0.0-rc1-update1"
+  }
+}

--- a/NetCore/global.json
+++ b/NetCore/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
-  "sdk": {
-    "version": "1.0.0-rc1-update1"
-  }
+	"sdk": {
+
+	}
 }

--- a/NetCore/src/Example/Example.cs
+++ b/NetCore/src/Example/Example.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using SendGrid.CSharp.HTTP.Client;
+using System.Web.Script.Serialization;
+
+// This is a working example, using the SendGrid API
+// You will need a SendGrid account and an active API Key
+// They key should be stored in an environment variable called SENDGRID_APIKEY
+namespace Example
+{
+    class Example
+    {
+        static void Main(string[] args)
+        {
+            String host = "https://e9sk3d3bfaikbpdq7.stoplight-proxy.io";
+            Dictionary<String, String> globalRequestHeaders = new Dictionary<String, String>();
+            string apiKey = Environment.GetEnvironmentVariable("SENDGRID_APIKEY", EnvironmentVariableTarget.User);
+            globalRequestHeaders.Add("Authorization", "Bearer " + apiKey);
+            globalRequestHeaders.Add("Content-Type", "application/json");
+
+            String version = "v3";
+            dynamic client = new Client(host: host, requestHeaders: globalRequestHeaders, version: version);
+
+            // GET Collection
+            string queryParams = @"{
+                'limit': 100
+            }";
+            Dictionary<String, String> requestHeaders = new Dictionary<String, String>();
+            requestHeaders.Add("X-Test", "test");
+            dynamic response = client.version("v3").api_keys.get(queryParams: queryParams, requestHeaders: requestHeaders);
+            // Console.WriteLine(response.StatusCode);
+            // Console.WriteLine(response.ResponseBody.ReadAsStringAsync().Result);
+            // Console.WriteLine(response.ResponseHeaders.ToString());
+
+            var dssResponseBody = response.DeserializeResponseBody(response.ResponseBody);
+            foreach ( var value in dssResponseBody["result"])
+            {
+                Console.WriteLine("name: {0}, api_key_id: {1}",value["name"], value["api_key_id"]);
+            }
+
+            var dssResponseHeaders = response.DeserializeResponseHeaders(response.ResponseHeaders);
+            foreach (var pair in dssResponseHeaders)
+            {
+                Console.WriteLine("{0}: {1}", pair.Key, pair.Value);
+            }
+
+            Console.WriteLine("\n\nPress any key to continue to POST.");
+            Console.ReadLine();
+
+            // POST
+            string requestBody = @"{
+                'name': 'My API Key 5',
+                'scopes': [
+                    'mail.send',
+                    'alerts.create',
+                    'alerts.read'
+                ]
+            }";
+            requestHeaders.Clear();
+            requestHeaders.Add("X-Test", "test2");
+            response = client.api_keys.post(requestBody: requestBody, requestHeaders: requestHeaders);
+            Console.WriteLine(response.StatusCode);
+            Console.WriteLine(response.ResponseBody.ReadAsStringAsync().Result);
+            Console.WriteLine(response.ResponseHeaders.ToString());
+            JavaScriptSerializer jss = new JavaScriptSerializer();
+            var ds_response = jss.Deserialize<Dictionary<string, dynamic>>(response.ResponseBody.ReadAsStringAsync().Result);
+            string api_key_id = ds_response["api_key_id"];
+
+            Console.WriteLine("\n\nPress any key to continue to GET single.");
+            Console.ReadLine();
+
+            // GET Single
+            response = client.api_keys._(api_key_id).get();
+            Console.WriteLine(response.StatusCode);
+            Console.WriteLine(response.ResponseBody.ReadAsStringAsync().Result);
+            Console.WriteLine(response.ResponseHeaders.ToString());
+
+            Console.WriteLine("\n\nPress any key to continue to PATCH.");
+            Console.ReadLine();
+
+            // PATCH
+            requestBody = @"{
+                'name': 'A New Hope'
+            }";
+            response = client.api_keys._(api_key_id).patch(requestBody: requestBody);
+            Console.WriteLine(response.StatusCode);
+            Console.WriteLine(response.ResponseBody.ReadAsStringAsync().Result);
+            Console.WriteLine(response.ResponseHeaders.ToString());
+
+            Console.WriteLine("\n\nPress any key to continue to PUT.");
+            Console.ReadLine();
+
+            // PUT
+            requestBody = @"{
+                'name': 'A New Hope',
+                'scopes': [
+                    'user.profile.read',
+                    'user.profile.update'
+                ]
+            }";
+            response = client.api_keys._(api_key_id).put(requestBody: requestBody);
+            Console.WriteLine(response.StatusCode);
+            Console.WriteLine(response.ResponseBody.ReadAsStringAsync().Result);
+            Console.WriteLine(response.ResponseHeaders.ToString());
+
+            Console.WriteLine("\n\nPress any key to continue to DELETE.");
+            Console.ReadLine();
+
+            // DELETE
+            response = client.api_keys._(api_key_id).delete();
+            Console.WriteLine(response.StatusCode);
+            Console.WriteLine(response.ResponseHeaders.ToString());
+
+            Console.WriteLine("\n\nPress any key to exit.");
+            Console.ReadLine();
+        }
+    }
+}

--- a/NetCore/src/Example/Example.xproj
+++ b/NetCore/src/Example/Example.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>0d6c6178-0950-41ca-aeb4-546f3fcfe9ee</ProjectGuid>
+    <RootNamespace>Example</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetCore/src/Example/Example.xproj
+++ b/NetCore/src/Example/Example.xproj
@@ -4,15 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>0d6c6178-0950-41ca-aeb4-546f3fcfe9ee</ProjectGuid>
     <RootNamespace>Example</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/NetCore/src/Example/Properties/AssemblyInfo.cs
+++ b/NetCore/src/Example/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Example")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Example")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0d6c6178-0950-41ca-aeb4-546f3fcfe9ee")]

--- a/NetCore/src/Example/project.json
+++ b/NetCore/src/Example/project.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0-*",
+  "description": "Example Console Application",
+  "authors": [ "ecelletti" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {
+    "SendGrid.CSharp.HTTP.Client": "1.0.0-*"
+  },
+
+  "commands": {
+    "Example": "Example"
+  },
+
+  "frameworks": {
+    "dnx451": { }
+  }
+}

--- a/NetCore/src/Example/project.json
+++ b/NetCore/src/Example/project.json
@@ -2,11 +2,8 @@
   "version": "1.0.0-*",
   "description": "Example Console Application",
   "authors": [ "ecelletti" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
 
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true
   },
 
@@ -19,6 +16,6 @@
   },
 
   "frameworks": {
-    "dnx451": { }
+    "net451": {}
   }
 }

--- a/NetCore/src/SendGrid.CSharp.HTTP.Client/Client.cs
+++ b/NetCore/src/SendGrid.CSharp.HTTP.Client/Client.cs
@@ -1,0 +1,351 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+#if NET451
+using System.Web.Script.Serialization;
+using System.Web;
+#else
+using Newtonsoft.Json;
+using System.Collections.Specialized;
+#endif
+
+namespace SendGrid.CSharp.HTTP.Client
+{
+    public class Response
+    {
+        public HttpStatusCode StatusCode;
+        public HttpContent ResponseBody;
+        public HttpResponseHeaders ResponseHeaders;
+
+        /// <summary>
+        ///     Holds the response from an API call.
+        /// </summary>
+        /// <param name="statusCode">https://msdn.microsoft.com/en-us/library/system.net.httpstatuscode(v=vs.110).aspx</param>
+        /// <param name="responseBody">https://msdn.microsoft.com/en-us/library/system.net.http.httpcontent(v=vs.118).aspx</param>
+        /// <param name="responseHeaders">https://msdn.microsoft.com/en-us/library/system.net.http.headers.httpresponseheaders(v=vs.118).aspx</param>
+        public Response(HttpStatusCode statusCode, HttpContent responseBody, HttpResponseHeaders responseHeaders)
+        {
+            StatusCode = statusCode;
+            ResponseBody = responseBody;
+            ResponseHeaders = responseHeaders;
+        }
+
+        /// <summary>
+        ///     Converts string formatted response body to a Dictionary.
+        /// </summary>
+        /// <param name="content">https://msdn.microsoft.com/en-us/library/system.net.http.httpcontent(v=vs.118).aspx</param>
+        /// <returns>Dictionary object representation of HttpContent</returns>
+        public virtual Dictionary<string, dynamic> DeserializeResponseBody(HttpContent content)
+        {
+#if NET451
+            JavaScriptSerializer jss = new JavaScriptSerializer();
+            var dsContent = jss.Deserialize<Dictionary<string, dynamic>>(content.ReadAsStringAsync().Result);
+#else
+            var dsContent = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(content.ReadAsStringAsync().Result);
+#endif
+            return dsContent;
+        }
+
+        /// <summary>
+        ///     Converts string formatted response headers to a Dictionary.
+        /// </summary>
+        /// <param name="content">https://msdn.microsoft.com/en-us/library/system.net.http.headers.httpresponseheaders(v=vs.118).aspx</param>
+        /// <returns>Dictionary object representation of  HttpRepsonseHeaders</returns>
+        public virtual Dictionary<string, string> DeserializeResponseHeaders(HttpResponseHeaders content)
+        {
+            var dsContent = new Dictionary<string, string>();
+            foreach (var pair in content)
+            {
+                dsContent.Add(pair.Key, pair.Value.First());
+            }
+            return dsContent;
+        }
+
+    }
+
+
+    public class Client : DynamicObject
+    {
+        public string Host;
+        public Dictionary <string,string> RequestHeaders;
+        public string Version;
+        public string UrlPath;
+        public string MediaType;
+        public enum Methods
+        {
+            DELETE, GET, PATCH, POST, PUT
+        }
+
+        /// <summary>
+        ///     REST API client.
+        /// </summary>
+        /// <param name="host">Base url (e.g. https://api.sendgrid.com)</param>
+        /// <param name="requestHeaders">A dictionary of request headers</param>
+        /// <param name="version">API version, override AddVersion to customize</param>
+        /// <param name="urlPath">Path to endpoint (e.g. /path/to/endpoint)</param>
+        /// <returns>Fluent interface to a REST API</returns>
+        public Client(string host, Dictionary<string,string> requestHeaders = null, string version = null, string urlPath = null)
+        {
+            Host = host;
+            if(requestHeaders != null)
+            {
+                AddRequestHeader(requestHeaders);
+            }
+            Version = (version != null) ? version : null;
+            UrlPath = (urlPath != null) ? urlPath : null;
+        }
+
+        /// <summary>
+        ///     Add requestHeaders to the API call
+        /// </summary>
+        /// <param name="requestHeaders">A dictionary of request headers</param>
+        public void AddRequestHeader(Dictionary<string, string> requestHeaders)
+        {
+            RequestHeaders = (RequestHeaders != null)
+                    ? RequestHeaders.Union(requestHeaders).ToDictionary(pair => pair.Key, pair => pair.Value) : requestHeaders;
+        }
+
+        /// <summary>
+        ///     Build the final URL
+        /// </summary>
+        /// <param name="queryParams">A string of JSON formatted query parameters (e.g {'param': 'param_value'})</param>
+        /// <returns>Final URL</returns>
+        private string BuildUrl(string queryParams = null)
+        {
+            string endpoint = null;
+
+            if( Version != null)
+            {
+                endpoint = Host + "/" + Version + UrlPath;
+            }
+            else
+            {
+                endpoint = Host + UrlPath;
+            }
+
+            if (queryParams != null)
+            {
+#if NET451
+                JavaScriptSerializer jss = new JavaScriptSerializer();
+                var ds_query_params = jss.Deserialize<Dictionary<string, dynamic>>(queryParams);
+                var query = HttpUtility.ParseQueryString(string.Empty);
+#else
+
+                var ds_query_params = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(queryParams);
+                var query = new NameValueCollection();
+#endif
+                foreach (var pair in ds_query_params)
+                {
+                    query[pair.Key] = pair.Value.ToString();
+                }
+                string queryString = query.ToString();
+                endpoint = endpoint + "?" + queryString;
+            }
+
+            return endpoint;
+        }
+
+        /// <summary>
+        ///     Create a new Client object for method chaining
+        /// </summary>
+        /// <param name="name">Name of url segment to add to the URL</param>
+        /// <returns>A new client object with "name" added to the URL</returns>
+        private Client BuildClient(string name = null)
+        {
+            string endpoint;
+
+            if (name != null)
+            {
+                endpoint = UrlPath + "/" + name;
+            }
+            else
+            {
+                endpoint = UrlPath;
+            }
+
+            UrlPath = null; // Reset the current object's state before we return a new one
+            return new Client(Host, RequestHeaders, Version, endpoint);
+
+        }
+
+        /// <summary>
+        ///     Add the authorization header, override to customize
+        /// </summary>
+        /// <param name="header">Authoriztion header</param>
+        /// <returns>Authorization value to add to the header</returns>
+        public virtual AuthenticationHeaderValue AddAuthorization(KeyValuePair<string, string> header)
+        {
+            string[] split = header.Value.Split(new char[0]);
+            return new AuthenticationHeaderValue(split[0], split[1]);
+        }
+
+        /// <summary>
+        ///     Add the version of the API, override to customize
+        /// </summary>
+        /// <param name="version">Version string to add to the URL</param>
+        public virtual void AddVersion(string version)
+        {
+            Version = version;
+        }
+
+        /// <summary>
+        ///     Deal with special cases and URL parameters
+        /// </summary>
+        /// <param name="name">Name of URL segment</param>
+        /// <returns>A new client object with "name" added to the URL</returns>
+        public Client _(string name)
+        {
+            return BuildClient(name);
+        }
+
+        /// <summary>
+        ///     Reflection. We capture undefined variable access here
+        /// </summary>
+        /// <param name="binder">The calling object properties</param>
+        /// <param name="result">The callback</param>
+        /// <returns>The callback returns a new client object with "name" added to the URL</returns>
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            result = BuildClient(binder.Name);
+            return true;
+        }
+
+        /// <summary>
+        ///     Reflection. We capture the final method call here
+        /// </summary>
+        /// <param name="binder">The calling object properties</param>
+        /// <param name="args">The calling object's arguements</param>
+        /// <param name="result">If "version", returns new client with version attached
+        ///                      If "method", returns a Response object</param>
+        /// <returns>The callback is described in "result"</returns>
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        {
+            if (binder.Name == "version")
+            {
+                AddVersion(args[0].ToString());
+                result = BuildClient();
+                return true;
+            }
+
+            if( Enum.IsDefined(typeof(Methods), binder.Name.ToUpper()))
+            {
+                string queryParams = null;
+                string requestBody = null;
+                int i = 0;
+
+                foreach (object obj in args)
+                {
+                    string name = binder.CallInfo.ArgumentNames.Count > i ?
+                       binder.CallInfo.ArgumentNames[i] : null;
+                    if (name == "queryParams")
+                    {
+                        queryParams = obj.ToString();
+                    }
+                    else if (name == "requestBody")
+                    {
+                        requestBody = obj.ToString();
+                    }
+                    else if (name == "requestHeaders")
+                    {
+                        AddRequestHeader((Dictionary<string, string>)obj);
+                    }
+                    i++;
+                }
+                result = RequestAsync(binder.Name.ToUpper(), requestBody: requestBody, queryParams: queryParams).Result;
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+
+        }
+
+        /// <summary>
+        ///     Make the call to the API server, override for testing or customization
+        /// </summary>
+        /// <param name="client">Client object ready for communication with API</param>
+        /// <param name="request">The parameters for the API call</param>
+        /// <returns>Response object</returns>
+        public async virtual Task<Response> MakeRequest(HttpClient client, HttpRequestMessage request)
+        {
+            HttpResponseMessage response = await client.SendAsync(request);
+            return new Response(response.StatusCode, response.Content, response.Headers);
+        }
+
+        /// <summary>
+        ///     Prepare for async call to the API server
+        /// </summary>
+        /// <param name="method">HTTP verb</param>
+        /// <param name="requestBody">JSON formatted string</param>
+        /// <param name="queryParams">JSON formatted queary paramaters</param>
+        /// <returns>Response object</returns>
+        private async Task<Response> RequestAsync(string method, String requestBody = null, String queryParams = null)
+        {
+            using (var client = new HttpClient())
+            {
+                try
+                {
+                    // Build the URL
+                    client.BaseAddress = new Uri(Host);
+                    string endpoint = BuildUrl(queryParams);
+
+                    // Build the request headers
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    if(RequestHeaders != null)
+                    {
+                        foreach (KeyValuePair<string, string> header in RequestHeaders)
+                        {
+                            if (header.Key == "Authorization")
+                            {
+                                client.DefaultRequestHeaders.Authorization = AddAuthorization(header);
+                            }
+                            else if (header.Key == "Content-Type")
+                            {
+                                MediaType = header.Value;
+                                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaType));
+                            }
+                            else
+                            {
+                                client.DefaultRequestHeaders.Add(header.Key, header.Value);
+                            }
+                        }
+                    }
+
+                    // Build the request body
+                    StringContent content = null;
+                    if (requestBody != null)
+                    {
+                        content = new StringContent(requestBody.ToString().Replace("'", "\""), Encoding.UTF8, MediaType);
+                    }
+
+                    // Build the final request
+                    HttpRequestMessage request = new HttpRequestMessage
+                    {
+                        Method = new HttpMethod(method),
+                        RequestUri = new Uri(endpoint),
+                        Content = content
+                    };
+                    return await MakeRequest(client, request);
+
+                }
+                catch (Exception ex)
+                {
+                    HttpResponseMessage response = new HttpResponseMessage();
+                    string message;
+                    message = (ex is HttpRequestException) ? ".NET HttpRequestException" : ".NET Exception";
+                    message = message + ", raw message: \n\n";
+                    response.Content = new StringContent(message + ex.Message);
+                    return new Response(response.StatusCode, response.Content, response.Headers);
+                }
+            }
+        }
+    }
+}

--- a/NetCore/src/SendGrid.CSharp.HTTP.Client/Properties/AssemblyInfo.cs
+++ b/NetCore/src/SendGrid.CSharp.HTTP.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SendGrid.CSharp.HTTP.Client")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SendGrid.CSharp.HTTP.Client")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("de550d30-b53d-4256-aebd-31fe5f4a43ba")]

--- a/NetCore/src/SendGrid.CSharp.HTTP.Client/SendGrid.CSharp.HTTP.Client.xproj
+++ b/NetCore/src/SendGrid.CSharp.HTTP.Client/SendGrid.CSharp.HTTP.Client.xproj
@@ -4,15 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>de550d30-b53d-4256-aebd-31fe5f4a43ba</ProjectGuid>
     <RootNamespace>SendGrid.CSharp.HTTP.Client</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/NetCore/src/SendGrid.CSharp.HTTP.Client/SendGrid.CSharp.HTTP.Client.xproj
+++ b/NetCore/src/SendGrid.CSharp.HTTP.Client/SendGrid.CSharp.HTTP.Client.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>de550d30-b53d-4256-aebd-31fe5f4a43ba</ProjectGuid>
+    <RootNamespace>SendGrid.CSharp.HTTP.Client</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetCore/src/SendGrid.CSharp.HTTP.Client/project.json
+++ b/NetCore/src/SendGrid.CSharp.HTTP.Client/project.json
@@ -1,0 +1,30 @@
+﻿{
+  "version": "1.0.0-*",
+  "description": "SendGrid.CSharp.HTTP.Client Class Library",
+  "authors": [ "ecelletti" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+  "dependencies": {
+    "System.Net.Http": "4.0.1-beta-23516"
+  },
+  "frameworks": {
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Web.Extensions": "4.0.0.0",
+        "System.Web": "4.0.0.0"
+      }
+    },
+    "dotnet5.4": {
+      "dependencies": {
+        "Microsoft.CSharp": "4.0.1-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Collections.Specialized": "4.0.1-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Threading": "4.0.11-beta-23516",
+        "Newtonsoft.Json": "8.0.3"
+      }
+    }
+  }
+}

--- a/NetCore/src/SendGrid.CSharp.HTTP.Client/project.json
+++ b/NetCore/src/SendGrid.CSharp.HTTP.Client/project.json
@@ -2,28 +2,27 @@
   "version": "1.0.0-*",
   "description": "SendGrid.CSharp.HTTP.Client Class Library",
   "authors": [ "ecelletti" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
   "dependencies": {
-    "System.Net.Http": "4.0.1-beta-23516"
   },
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
         "System.Web.Extensions": "4.0.0.0",
-        "System.Web": "4.0.0.0"
+        "System.Web": "4.0.0.0",
+        "System.Net.Http": "4.0.0"
       }
     },
-    "dotnet5.4": {
+    "netstandard1.3": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-beta-23516",
-        "System.Collections": "4.0.11-beta-23516",
-        "System.Collections.Specialized": "4.0.1-beta-23516",
-        "System.Linq": "4.0.1-beta-23516",
-        "System.Runtime": "4.0.21-beta-23516",
-        "System.Threading": "4.0.11-beta-23516",
-        "Newtonsoft.Json": "8.0.3"
+        "System.Runtime.InteropServices": "4.1.0",
+        "System.Net.Http": "4.1.0",
+        "Microsoft.CSharp": "4.0.1",
+        "System.Collections": "4.0.11",
+        "System.Collections.Specialized": "4.0.1",
+        "System.Linq": "4.1.0",
+        "System.Runtime": "4.1.0",
+        "System.Threading": "4.0.11",
+        "Newtonsoft.Json": "9.0.1"
       }
     }
   }

--- a/NetCore/test/UnitTest/Properties/AssemblyInfo.cs
+++ b/NetCore/test/UnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("UnitTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UnitTest")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("661b8eea-0919-4b66-abb6-449432053cba")]

--- a/NetCore/test/UnitTest/UnitTest.cs
+++ b/NetCore/test/UnitTest/UnitTest.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using SendGrid.CSharp.HTTP.Client;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Text;
+using System.Net;
+using Xunit;
+
+namespace UnitTest
+{
+
+    // Mock the Client so that we intercept network calls
+    public class MockClient : Client
+    {
+        public MockClient(string host, Dictionary<string, string> requestHeaders = null, string version = null, string urlPath = null) : base (host, requestHeaders, version, urlPath)
+        {
+        }
+
+        public async override Task<Response> MakeRequest(HttpClient client, HttpRequestMessage request)
+        {
+            HttpResponseMessage response = new HttpResponseMessage();
+            response.Content = new StringContent("{'test': 'test_content'}", Encoding.UTF8, "application/json");
+            response.StatusCode = HttpStatusCode.OK;
+            return new Response(response.StatusCode, response.Content, response.Headers);
+        }
+    }
+    
+    public class TestClient
+    {
+        [Fact]
+        public void TestInitialization()
+        {
+            var host = "http://api.test.com";
+            Dictionary<String, String> requestHeaders = new Dictionary<String, String>();
+            var version = "v3";
+            var urlPath = "/test/url/path";
+            var test_client = new MockClient(host: host, requestHeaders: requestHeaders, version: version, urlPath: urlPath);
+            requestHeaders.Add("Authorization", "Bearer SG.XXXX");
+            requestHeaders.Add("Content-Type", "application/json");
+            requestHeaders.Add("X-TEST", "test");
+            Assert.NotNull(test_client);
+            Assert.Equal(host, test_client.Host);
+            Assert.Equal(requestHeaders, test_client.RequestHeaders);
+            Assert.Equal(version, test_client.Version);
+            Assert.Equal(urlPath, test_client.UrlPath);
+        }
+
+        [Fact]
+        public void TestReflection()
+        {
+            var host = "http://api.test.com";
+            dynamic test_client = new MockClient(host: host);
+            dynamic url1 = test_client.my.test.path;
+            Assert.Equal(url1.UrlPath, "/my/test/path");
+            url1 = test_client.my._("test").path;
+            Assert.Equal(url1.UrlPath, "/my/test/path");
+            url1 = test_client.version("v4").my.test.path;
+            Assert.Equal(url1.Version, "v4");
+            Assert.Equal(url1.UrlPath, "/my/test/path");
+            url1 = url1.final.result;
+            Assert.Equal(url1.UrlPath, "/my/test/path/final/result");
+        }
+
+        [Fact]
+        public void TestMethodCall()
+        {
+            var host = "http://api.test.com";
+            dynamic test_client = new MockClient(host: host);
+            Response response = test_client.get();
+            Assert.NotNull(response);
+            Assert.Equal(response.StatusCode, HttpStatusCode.OK);
+            var content = new StringContent("{'test': 'test_content'}", Encoding.UTF8, "application/json");
+            Assert.Equal(response.ResponseBody.ReadAsStringAsync().Result, content.ReadAsStringAsync().Result);
+        }
+    }
+}

--- a/NetCore/test/UnitTest/UnitTest.xproj
+++ b/NetCore/test/UnitTest/UnitTest.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>661b8eea-0919-4b66-abb6-449432053cba</ProjectGuid>
+    <RootNamespace>UnitTest</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetCore/test/UnitTest/UnitTest.xproj
+++ b/NetCore/test/UnitTest/UnitTest.xproj
@@ -4,15 +4,13 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>661b8eea-0919-4b66-abb6-449432053cba</ProjectGuid>
     <RootNamespace>UnitTest</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/NetCore/test/UnitTest/project.json
+++ b/NetCore/test/UnitTest/project.json
@@ -1,0 +1,19 @@
+﻿{
+  "version": "1.0.0-*",
+  "description": "UnitTest Class Library",
+  "authors": [ "ecelletti" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+  "frameworks": {
+    "dnxcore50": { }
+  },
+  "dependencies": {
+    "SendGrid.CSharp.HTTP.Client": "1.0.0-*",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
+  },
+  "commands": {
+    "test": "xunit.runner.dnx"
+  }
+}

--- a/NetCore/test/UnitTest/project.json
+++ b/NetCore/test/UnitTest/project.json
@@ -1,19 +1,28 @@
 ﻿{
   "version": "1.0.0-*",
   "description": "UnitTest Class Library",
-  "authors": [ "ecelletti" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
+  "authors": [ "" ],
+
+  "testRunner": "xunit",
+
   "frameworks": {
-    "dnxcore50": { }
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0",
+          "type": "platform"
+        }
+      },
+      "imports": [
+        "dotnet5.6",
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
   },
   "dependencies": {
     "SendGrid.CSharp.HTTP.Client": "1.0.0-*",
-    "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204"
-  },
-  "commands": {
-    "test": "xunit.runner.dnx"
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }
 }


### PR DESCRIPTION
…t Core/.Net Core solution/project type

I ported the solution to the new project/solution formats. It targets the net451 and [dotnet5.4](https://github.com/aspnet/Announcements/issues/98). 

Key points:
- .Net 451 builds will be exactly the same
- .Net Core builds require Newtownsoft.Json (no more JsonSeriliaizer or whatever)
- I left the versioning, license urls, author info alone so none of those are set
- I could not get NUnit to work with the unit test project so it is now using xUnit (no real difference)
- The project name has to be the full namespace if you want your dll to be your namespace
- Tests still run and it still builds the .Net 451 dll
- I put the .Net Core stuff in the NetCore folder and didnt affect what is currently there so I dont completely destroy anything anyone was working on. But the new solution can replace the old one
