### PR TITLE
Tests looking for wrong file type for License

### DIFF
--- a/UnitTest/UnitTest.cs
+++ b/UnitTest/UnitTest.cs
@@ -104,7 +104,7 @@ namespace UnitTest
         [Test]
         public void TestLicenseEndYear()
         {
-            var licensePath = Path.Combine("..", "..", "..", "LICENSE.txt");
+            var licensePath = Path.Combine("..", "..", "..", "LICENSE.md");
             string line = File.ReadLines(licensePath).Skip(2).Take(1).First();
 
             Assert.AreEqual(DateTime.Now.Year.ToString(), line.Substring(19, 4));


### PR DESCRIPTION
### Short description of what this PR does:

Travis pipeline failing on the `TestRepositoryFiles` license test as the license file type was incorrect. Updated to `.md`

Fixes #76 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified
