### PR TITLE
Fix location of LICENSE.md file in Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis Badge](https://travis-ci.org/sendgrid/csharp-http-client.svg?branch=master)](https://travis-ci.org/sendgrid/csharp-http-client)
 [![NuGet](https://img.shields.io/nuget/v/SendGrid.CSharp.Http.Client.svg)](https://www.nuget.org/packages/SendGrid.CSharp.HTTP.Client)
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.txt)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)
 [![Twitter Follow](https://img.shields.io/twitter/follow/sendgrid.svg?style=social&label=Follow)](https://twitter.com/sendgrid)
 [![GitHub contributors](https://img.shields.io/github/contributors/sendgrid/csharp-http-client.svg)](https://github.com/sendgrid/csharp-http-client/graphs/contributors)
 

--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ csharp-http-client is guided and supported by the SendGrid [Developer Experience
 csharp-http-client is maintained and funded by SendGrid, Inc. The names and logos for csharp-http-client are trademarks of SendGrid, Inc.
 
 # License
-[The MIT License (MIT)](LICENSE.txt)
+[The MIT License (MIT)](LICENSE.md)

--- a/UnitTest/UnitTest.cs
+++ b/UnitTest/UnitTest.cs
@@ -104,7 +104,7 @@ namespace UnitTest
         [Test]
         public void TestLicenseEndYear()
         {
-            var licensePath = Path.Combine("..", "..", "..", "LICENSE.txt");
+            var licensePath = Path.Combine("..", "..", "..", "LICENSE.md");
             string line = File.ReadLines(licensePath).Skip(2).Take(1).First();
 
             Assert.AreEqual(DateTime.Now.Year.ToString(), line.Substring(19, 4));

--- a/nuspec/SendGrid.CSharp.HTTP.Client.3.3.0.nuspec
+++ b/nuspec/SendGrid.CSharp.HTTP.Client.3.3.0.nuspec
@@ -5,7 +5,7 @@
         <version>3.3.0</version>
         <title>Fluent REST API Client</title>
         <authors>Elmer Thomas,SendGrid DX Team</authors>
-        <licenseUrl>https://github.com/sendgrid/csharp-http-client/blob/master/LICENSE</licenseUrl>
+        <licenseUrl>https://github.com/sendgrid/csharp-http-client/blob/master/LICENSE.md</licenseUrl>
         <projectUrl>https://github.com/sendgrid/csharp-http-client</projectUrl>
         <iconUrl>https://sendgrid.com/wp-content/themes/sgdotcom/pages/brand/2016/SendGrid-Logomark.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Just as in the other PR's below, this PR fixes links to your `README.md` file so the link is correct to your MIT License. :+1: 

Similar to: 
- https://github.com/sendgrid/sendgrid-java/pull/513
- https://github.com/sendgrid/java-http-client/pull/109


### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
Fixes link in `README.md` to the license file, which is proparly located at `LICENSE.md` not `LICENSE.txt`
